### PR TITLE
Upgrade kafka-clients dependency for Kafka 4.x compatibility

### DIFF
--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/pom.xml
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/pom.xml
@@ -377,7 +377,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.10.2.2</version>
+            <version>3.7.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

This PR upgrades the kafka-clients dependency to a version compatible with Kafka 4.x.